### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates for more information about this file.
+
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We'll then get PRs for updates to Composer packages and the GitHub Actions.

One thing to watch is will Dependabot know that this repository is a library rather than a project? I would believe yes based on https://getcomposer.org/doc/04-schema.md#type defaulting to _library_ and `composer.lock` being in `.gitignore`. Hopefully that all means we'll only get PRs for major versions or updates outside of the ranges.