### PR TITLE
Update client behaviour of getEmailResponseSummary call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mention-me/emarsys",
     "description": "Emarsys RestFull API client",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.3",
         "psr/http-client": "^1.0.1",
         "ext-json": "*"
     },

--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -409,9 +409,29 @@ class Client implements \Snowcap\Emarsys\ClientInterface
     /**
      * {@inheritDoc}
      */
-    public function getEmailResponseSummary(string $emailId, array $data): Response
+    public function getEmailResponseSummary(string $emailId, ?string $startDate = null, ?string $endDate = null, string $launchId = null): Response
     {
-        return $this->send($this::POST, sprintf('email/%s/responsesummary', $emailId), $data);
+        $data = [];
+
+        if (null !== $startDate) {
+            $data['start_date'] = $startDate;
+        }
+
+        if (null !== $endDate) {
+            $data['end_date'] = $endDate;
+        }
+
+        if (null !== $launchId) {
+            $data['launch_id'] = $launchId;
+        }
+
+        $url = sprintf('email/%s/responsesummary', $emailId);
+
+        if (count($data) > 0) {
+            $url = sprintf('%s/%s', $url, http_build_query($data));
+        }
+
+        return $this->send($this::GET, $url);
     }
 
     /**

--- a/src/Snowcap/Emarsys/ClientInterface.php
+++ b/src/Snowcap/Emarsys/ClientInterface.php
@@ -363,14 +363,16 @@ interface ClientInterface
     /**
      * Returns the summary of the responses of a launched, paused, activated or deactivated email.
      *
-     * @param string $emailId
-     * @param array $data
+     * @param string      $emailId
+     * @param string|null $startDate
+     * @param string|null $endDate
+     * @param string|null $launchId
      *
      * @return Response
      * @throws ClientException
      * @throws ServerException
      */
-    public function getEmailResponseSummary(string $emailId, array $data): Response;
+    public function getEmailResponseSummary(string $emailId, ?string $startDate = null, ?string $endDate = null, string $launchId = null): Response;
 
     /**
      * Instructs the system to send a test email.

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -309,6 +309,22 @@ class ClientTest extends TestCase
     }
 
     /**
+     * @throws ClientException
+     * @throws ServerException
+     * @throws Exception
+     */
+    public function testItReturnsEmailResponseSummary(): void
+    {
+        $expectedResponse = $this->createMock(ResponseInterface::class);
+        $expectedResponse->method("getBody")->willReturn($this->createExpectedResponse('getEmailResponseSummary'));
+        $this->stubHttpClient->addResponse($expectedResponse);
+
+        $response = $this->client->getEmailResponseSummary(12345);
+
+        self::assertEquals(90, $response->getData()['sent']);
+    }
+
+    /**
      * Get a json test data and decode it
      *
      * @param string $fileName

--- a/tests/Unit/Suites/TestData/getEmailResponseSummary.json
+++ b/tests/Unit/Suites/TestData/getEmailResponseSummary.json
@@ -1,0 +1,17 @@
+{
+    "replyCode": 0,
+    "replyText": "OK",
+    "data": {
+        "sent": 90,
+        "planned": "0",
+        "soft_bounces": 0,
+        "hard_bounces": "2",
+        "block_bounces": 0,
+        "opened": "6",
+        "unsubscribe": "0",
+        "total_clicks": "0",
+        "unique_clicks": "0",
+        "complained": "0",
+        "launches": "6"
+    }
+}


### PR DESCRIPTION
See:

* https://dev.emarsys.com/v2/email-campaign-life-cycle/get-a-response-summary

For the call to the Emarsys API endpoint for a response summary we should fire a _`GET`_ request at `/v2/email/{emailId}/responsesummary`. However, the client sends a `POST` which tries to encode the data into the body of the request, but the Emarsys API only understands the start and end date parameters when they appear in the query (as we have to make an `application/json` request, it won't understand forms or other body types.)

This PR adjusts it appropriately to the API specification and adds a small test for the expected payload returned.