### PR TITLE
Tweaks for including some constants and better parameter usage

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -18,7 +18,6 @@ class Client implements EmarsysClientInterface
     public const HTTP_POST = 'POST';
     public const HTTP_PUT = 'PUT';
     public const HTTP_DELETE = 'DELETE';
-
     public const LIVE_BASE_URL = 'https://api.emarsys.net/api/v2/';
 
     /**
@@ -82,16 +81,15 @@ class Client implements EmarsysClientInterface
      * @param array                   $choicesMapping Overrides the default choices mapping if needed
      */
     public function __construct(
-        HttpClientInterface     $client,
+        HttpClientInterface $client,
         RequestFactoryInterface $requestFactory,
-        StreamFactoryInterface  $streamFactory,
-        string                  $username,
-        string                  $secret,
-                                $baseUrl = null,
-                                $fieldsMapping = [],
-                                $choicesMapping = []
-    )
-    {
+        StreamFactoryInterface $streamFactory,
+        string $username,
+        string $secret,
+        $baseUrl = null,
+        $fieldsMapping = [],
+        $choicesMapping = []
+    ) {
         $this->client = $client;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
@@ -124,10 +122,10 @@ class Client implements EmarsysClientInterface
         foreach ($mapping as $fieldStringId => $choices) {
             if (is_array($choices)) {
                 if ( ! array_key_exists($fieldStringId, $this->choicesMapping)) {
-                    $this->choicesMapping[ $fieldStringId ] = [];
+                    $this->choicesMapping[$fieldStringId] = [];
                 }
 
-                $this->choicesMapping[ $fieldStringId ] = array_merge($this->choicesMapping[ $fieldStringId ], $choices);
+                $this->choicesMapping[$fieldStringId] = array_merge($this->choicesMapping[$fieldStringId], $choices);
             }
         }
     }
@@ -138,11 +136,11 @@ class Client implements EmarsysClientInterface
             return $fieldStringId;
         }
 
-        if ( ! isset($this->fieldsMapping[ $fieldStringId ])) {
+        if ( ! isset($this->fieldsMapping[$fieldStringId])) {
             throw ClientException::unrecognizedFieldName($fieldStringId);
         }
 
-        return (int)$this->fieldsMapping[ $fieldStringId ];
+        return (int) $this->fieldsMapping[$fieldStringId];
     }
 
     public function getFieldStringId($fieldId)
@@ -162,11 +160,11 @@ class Client implements EmarsysClientInterface
             throw ClientException::unrecognizedFieldStringIdForChoice($fieldStringId, $choice);
         }
 
-        if ( ! isset($this->choicesMapping[ $fieldStringId ][ $choice ])) {
+        if ( ! isset($this->choicesMapping[$fieldStringId][$choice])) {
             throw ClientException::unrecognizedChoiceForFieldStringId($choice, $fieldStringId);
         }
 
-        return (int)$this->choicesMapping[ $fieldStringId ][ $choice ];
+        return (int) $this->choicesMapping[$fieldStringId][$choice];
     }
 
     public function getChoiceName($fieldId, int $choiceId)
@@ -180,7 +178,7 @@ class Client implements EmarsysClientInterface
             throw ClientException::unrecognizedFieldStringIdForChoice($fieldId, $choiceId);
         }
         $choiceName = null;
-        foreach ($this->choicesMapping[ $fieldId ] as $key => $choiceValue) {
+        foreach ($this->choicesMapping[$fieldId] as $key => $choiceValue) {
             // The id in the choicesMapping is a string so we only use == for comparison
             if ($choiceId == $choiceValue) {
                 $choiceName = $key;
@@ -400,8 +398,12 @@ class Client implements EmarsysClientInterface
     /**
      * {@inheritDoc}
      */
-    public function getEmailResponseSummary(string $emailId, ?string $startDate = null, ?string $endDate = null, string $launchId = null): Response
-    {
+    public function getEmailResponseSummary(
+        string $emailId,
+        ?string $startDate = null,
+        ?string $endDate = null,
+        string $launchId = null
+    ): Response {
         $data = [];
 
         if (null !== $startDate) {
@@ -691,8 +693,7 @@ class Client implements EmarsysClientInterface
         $created = new DateTime();
         $iso8601 = $created->format(DateTime::ATOM);
         // the md5 of a random string . e.g. a timestamp
-        $nonce = md5($created->modify('next friday')
-                             ->getTimestamp());
+        $nonce = md5($created->modify('next friday')->getTimestamp());
         // The algorithm to generate the digest is as follows:
         // Concatenate: Nonce + Created + Secret
         // Hash the result using the SHA1 algorithm
@@ -724,9 +725,9 @@ class Client implements EmarsysClientInterface
 
         foreach ($data as $fieldStringId => $value) {
             if (is_numeric($fieldStringId)) {
-                $mappedData[ (int)$fieldStringId ] = $value;
+                $mappedData[(int) $fieldStringId] = $value;
             } else {
-                $mappedData[ $this->getFieldId($fieldStringId) ] = $value;
+                $mappedData[$this->getFieldId($fieldStringId)] = $value;
             }
         }
 
@@ -787,7 +788,7 @@ class Client implements EmarsysClientInterface
     {
         $mapping = [];
         foreach ($data as $field) {
-            $mapping[ $field['string_id'] ] = $field['id'];
+            $mapping[$field['string_id']] = $field['id'];
         }
 
         return $mapping;
@@ -828,9 +829,9 @@ class Client implements EmarsysClientInterface
         $mapping = [];
         foreach ($data as $key => $value) {
             $fieldStringId = $this->getFieldStringId($key);
-            $mapping[ $fieldStringId ] = [];
+            $mapping[$fieldStringId] = [];
             foreach ($value as $choice) {
-                $mapping[ $fieldStringId ] = [ $choice['choice'] => $choice['id'] ];
+                $mapping[$fieldStringId] = [$choice['choice'] => $choice['id']];
             }
         }
 

--- a/src/Snowcap/Emarsys/ClientInterface.php
+++ b/src/Snowcap/Emarsys/ClientInterface.php
@@ -7,6 +7,29 @@ use Snowcap\Emarsys\Exception\ServerException;
 
 interface ClientInterface
 {
+    public const LAUNCH_STATUS_NOT_LAUNCHED = 0;
+    public const LAUNCH_STATUS_IN_PROGRESS = 1;
+    public const LAUNCH_STATUS_LAUNCHED_OR_SCHEDULED = 2;
+    public const LAUNCH_STATUS_ERROR = 10;
+
+    /**
+     * @see https://dev.emarsys.com/v2/personalization/email-status-and-error-codes for codes
+     */
+    public const EMAIL_STATUS_CODE_ABORTED = -6;
+    public const EMAIL_STATUS_CODE_PAUSED_ABORTED = -4;
+    public const EMAIL_STATUS_CODE_LAUNCHED_PAUSED = -3;
+    public const EMAIL_STATUS_CODE_TESTED_PAUSED = -2;
+    public const EMAIL_STATUS_CODE_IN_DESIGN = 1;
+    public const EMAIL_STATUS_CODE_TESTED = 2;
+    public const EMAIL_STATUS_CODE_LAUNCHED = 3;
+    public const EMAIL_STATUS_CODE_READY_TO_LAUNCH = 4;
+    public const EMAIL_STATUS_CODE_NOT_LAUNCHED = 5;
+
+    /**
+     * @see https://dev.emarsys.com/v2/response-codes where success is defined as zero
+     */
+    public const API_REPLY_CODE_SUCCESS = 0;
+
     /**
      * Add your custom fields mapping
      * This is useful if you want to use string identifiers instead of ids when you play with contacts fields

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -184,7 +184,7 @@ class ClientTest extends TestCase
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
-        $response = $this->client->getEmails(Client::EMAIL_STATUS_READY);
+        $response = $this->client->getEmails(Client::API_EMAIL_STATUS_READY_TO_LAUNCH);
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
@@ -192,7 +192,7 @@ class ClientTest extends TestCase
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
-        $response = $this->client->getEmails(Client::EMAIL_STATUS_READY, 123);
+        $response = $this->client->getEmails(Client::API_EMAIL_STATUS_READY_TO_LAUNCH, 123);
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         self::assertNotEmpty($response->getData());

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -184,7 +184,7 @@ class ClientTest extends TestCase
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
-        $response = $this->client->getEmails(Client::API_EMAIL_STATUS_READY_TO_LAUNCH);
+        $response = $this->client->getEmails(ClientInterface::EMAIL_STATUS_CODE_READY_TO_LAUNCH);
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
@@ -192,7 +192,7 @@ class ClientTest extends TestCase
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         $this->stubHttpClient->addResponse($expectedResponse);
-        $response = $this->client->getEmails(Client::API_EMAIL_STATUS_READY_TO_LAUNCH, 123);
+        $response = $this->client->getEmails(ClientInterface::EMAIL_STATUS_CODE_READY_TO_LAUNCH, 123);
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
         self::assertNotEmpty($response->getData());


### PR DESCRIPTION
Moved the constants to this library's _interface_, as per comment on our use here:

* https://github.com/mention-me/MentionMe/pull/10895#discussion_r728998024

Have also taken the opportunity to tidy up a few other things that unravelled from putting the constants in:

* More clearly defined the `ClientInterface` for Emarsys or HTTP requests
* Tweaked naming of constants, also merged/removed existing constants
* Have put the Emarsys API service constants on the _interface_ as they will always be attached to the API endpoint and not the client implementation
* Moved the HTTP verb to the final parameter of `send` rather than the first (which had an unusable default value of `GET`)

Note: some of the methods are probably still inconsistent with their actual API usage/documentation - have only looked and included the methods/constants for the endpoints we're working with currently.