### PR TITLE
Add campaign type filter to get emails

### DIFF
--- a/src/Snowcap/Emarsys/Client.php
+++ b/src/Snowcap/Emarsys/Client.php
@@ -20,24 +20,6 @@ class Client implements EmarsysClientInterface
     public const HTTP_DELETE = 'DELETE';
     public const LIVE_BASE_URL = 'https://api.emarsys.net/api/v2/';
 
-    public const CAMPAIGN_TYPE_ADHOC = 'adhoc';
-    public const CAMPAIGN_TYPE_RECURRING = 'recurring';
-    public const CAMPAIGN_TYPE_NEWSLETTER = 'newsletter';
-    public const CAMPAIGN_TYPE_ON_EVENT = 'onevent';
-    public const CAMPAIGN_TYPE_TEST_EMAIL = 'testemail';
-    public const CAMPAIGN_TYPE_MULTILANGUAGE = 'multilanguage';
-    public const CAMPAIGN_TYPE_BROADCAST = 'broadcast';
-
-    public const CAMPAIGN_TYPES = [
-        self::CAMPAIGN_TYPE_ADHOC,
-        self::CAMPAIGN_TYPE_RECURRING,
-        self::CAMPAIGN_TYPE_NEWSLETTER,
-        self::CAMPAIGN_TYPE_ON_EVENT,
-        self::CAMPAIGN_TYPE_TEST_EMAIL,
-        self::CAMPAIGN_TYPE_MULTILANGUAGE,
-        self::CAMPAIGN_TYPE_BROADCAST,
-    ];
-
     /**
      * @var string
      */
@@ -379,7 +361,7 @@ class Client implements EmarsysClientInterface
     /**
      * {@inheritDoc}
      */
-    public function getEmails($status = null, $contactList = null, array $campaignTypes): Response
+    public function getEmails($status = null, $contactList = null, array $campaignTypes = []): Response
     {
         $data = [];
         if (null !== $status) {

--- a/src/Snowcap/Emarsys/ClientInterface.php
+++ b/src/Snowcap/Emarsys/ClientInterface.php
@@ -42,7 +42,7 @@ interface ClientInterface
      *
      * @param array $mapping
      */
-    public function addFieldsMapping($mapping = []): void;
+    public function addFieldsMapping(array $mapping = []): void;
 
     /**
      * Add your custom field choices mapping
@@ -58,7 +58,7 @@ interface ClientInterface
      *
      * @param array $mapping
      */
-    public function addChoicesMapping($mapping = []): void;
+    public function addChoicesMapping(array $mapping = []): void;
 
     /**
      * Returns a field id from a field string_id (specified in the fields mapping)
@@ -314,12 +314,14 @@ interface ClientInterface
      *
      * @param int|null $status
      * @param int|null $contactList
+     * @param array $campaignTypes
      *
      * @return Response
      * @throws ClientException
      * @throws ServerException
+     * @link https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns
      */
-    public function getEmails($status = null, $contactList = null): Response;
+    public function getEmails(?int $status = null, ?int $contactList = null, array $campaignTypes): Response;
 
     /**
      * Creates an email in eMarketing Suite and assigns it the respective parameters.

--- a/src/Snowcap/Emarsys/ClientInterface.php
+++ b/src/Snowcap/Emarsys/ClientInterface.php
@@ -26,6 +26,17 @@ interface ClientInterface
     public const EMAIL_STATUS_CODE_NOT_LAUNCHED = 5;
 
     /**
+     * @see https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns
+     */
+    public const CAMPAIGN_TYPE_ADHOC = 'adhoc';
+    public const CAMPAIGN_TYPE_RECURRING = 'recurring';
+    public const CAMPAIGN_TYPE_NEWSLETTER = 'newsletter';
+    public const CAMPAIGN_TYPE_ON_EVENT = 'onevent';
+    public const CAMPAIGN_TYPE_TEST_EMAIL = 'testemail';
+    public const CAMPAIGN_TYPE_MULTILANGUAGE = 'multilanguage';
+    public const CAMPAIGN_TYPE_BROADCAST = 'broadcast';
+
+    /**
      * @see https://dev.emarsys.com/v2/response-codes where success is defined as zero
      */
     public const API_REPLY_CODE_SUCCESS = 0;

--- a/tests/Integration/Suites/EmarsysTest.php
+++ b/tests/Integration/Suites/EmarsysTest.php
@@ -49,7 +49,7 @@ class EmarsysTest extends TestCase
     }
 
     /**
-     * @covers \Snowcap\Emarsys\Client::getLanguages
+     * @covers Client::getLanguages
      * @throws ServerException
      * @throws ClientException
      * @throws Exception
@@ -57,6 +57,8 @@ class EmarsysTest extends TestCase
     public function testItShouldGetAvailableLanguages(): void
     {
         $response = $this->client->getLanguages();
+
+        // The language string values used to be all lowercase, but now they are capitalized
         $expectation = [
             'id'       => 'en',
             'language' => 'English',
@@ -66,7 +68,7 @@ class EmarsysTest extends TestCase
     }
 
     /**
-     * @covers \Snowcap\Emarsys\Client::getFields
+     * @covers Client::getFields
      * @throws ServerException
      * @throws ClientException
      * @throws Exception

--- a/tests/Integration/Suites/EmarsysTest.php
+++ b/tests/Integration/Suites/EmarsysTest.php
@@ -49,6 +49,7 @@ class EmarsysTest extends TestCase
     }
 
     /**
+     * @covers \Snowcap\Emarsys\Client::getLanguages
      * @throws ServerException
      * @throws ClientException
      * @throws Exception
@@ -58,13 +59,14 @@ class EmarsysTest extends TestCase
         $response = $this->client->getLanguages();
         $expectation = [
             'id'       => 'en',
-            'language' => 'english',
+            'language' => 'English',
         ];
 
         self::assertContains($expectation, $response->getData());
     }
 
     /**
+     * @covers \Snowcap\Emarsys\Client::getFields
      * @throws ServerException
      * @throws ClientException
      * @throws Exception

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -195,6 +195,10 @@ class ClientTest extends TestCase
         $response = $this->client->getEmails(ClientInterface::EMAIL_STATUS_CODE_READY_TO_LAUNCH, 123);
         self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
 
+        $this->stubHttpClient->addResponse($expectedResponse);
+        $response = $this->client->getEmails(ClientInterface::EMAIL_STATUS_CODE_READY_TO_LAUNCH, 123, [ClientInterface::CAMPAIGN_TYPE_ON_EVENT]);
+        self::assertEquals(Response::REPLY_CODE_OK, $response->getReplyCode());
+
         self::assertNotEmpty($response->getData());
 
         foreach ($response->getData() as $data) {


### PR DESCRIPTION
Added a `campaign_types` parameter to the `getEmails` client method to be able to filter by campaign type.
See: https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns