### PR TITLE
[Part 2] Modernise code

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
+    - name: Run Rector
+      run: composer rector --dry-run
 
     - name: Run test suite
       run: composer test

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "scripts": {
         "test": "phpunit tests/",
-        "rector": "rector"
+        "rector": "rector --dry-run"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^10",
         "php-http/mock-client": "^1.4.1",
         "guzzlehttp/guzzle": "^7.0.1",
         "http-interop/http-factory-guzzle": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
             "email": "jerome@snowcap.be"
         },
         {
-            "name": "Alex Oanea",
-            "email": "alex.oanea@mention-me.com"
+            "name": "Ryan Maber",
+            "email": "ryan.maber@mention-me.com"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit tests/ --verbose"
+        "test": "phpunit tests/ --verbose",
+        "rector": "rector"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit tests/ --verbose",
+        "test": "phpunit tests/",
         "rector": "rector"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "phpunit/phpunit": "^9",
         "php-http/mock-client": "^1.4.1",
         "guzzlehttp/guzzle": "^7.0.1",
-        "http-interop/http-factory-guzzle": "^1.0.0"
+        "http-interop/http-factory-guzzle": "^1.0.0",
+        "rector/rector": "^1.0"
     },
     "minimum-stability": "stable",
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c465b7090663ba343f41114a901e57a",
+    "content-hash": "96556620d405339fc590d419c4b0dbe8",
     "packages": [
         {
             "name": "psr/http-client",
@@ -178,76 +178,6 @@
                 }
             ],
             "time": "2023-12-20T15:40:13+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1315,16 +1245,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "10.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
                 "shasum": ""
             },
             "require": {
@@ -1332,18 +1262,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1352,7 +1282,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -1381,7 +1311,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
             },
             "funding": [
                 {
@@ -1389,32 +1319,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-03-12T15:33:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1441,7 +1371,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -1449,28 +1380,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1478,7 +1409,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1504,7 +1435,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1512,32 +1443,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1563,7 +1494,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1571,32 +1503,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1622,7 +1554,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1630,24 +1562,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "10.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -1657,27 +1588,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.5",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.1",
+                "sebastian/global-state": "^6.0.1",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -1685,7 +1615,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -1717,7 +1647,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
             },
             "funding": [
                 {
@@ -1733,7 +1663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-04-24T06:32:35+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1895,28 +1825,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1939,7 +1869,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1947,32 +1878,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1995,7 +1926,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2003,32 +1934,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2050,7 +1981,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2058,34 +1989,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2124,7 +2057,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2132,33 +2066,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2181,7 +2115,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -2189,33 +2124,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2247,7 +2182,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -2255,27 +2191,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2283,7 +2219,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -2302,7 +2238,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2310,7 +2246,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -2318,34 +2255,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2387,7 +2324,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -2395,38 +2333,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2445,13 +2380,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -2459,33 +2395,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2508,7 +2444,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -2516,34 +2453,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2565,7 +2502,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2573,32 +2510,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2620,7 +2557,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2628,32 +2565,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2683,7 +2620,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2691,86 +2628,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2793,7 +2676,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2801,29 +2684,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2846,7 +2729,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2854,7 +2737,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b04e49eb4aad407111bcfa3b50c9d3e",
+    "content-hash": "1c465b7090663ba343f41114a901e57a",
     "packages": [
         {
             "name": "psr/http-client",
@@ -1256,6 +1256,64 @@
             "time": "2024-03-15T13:55:21+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "1.10.67",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-16T07:22:02+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "9.2.31",
             "source": {
@@ -1775,6 +1833,65 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "6e04d0eb087aef707fa0c5686d33d6ff61f4a555"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/6e04d0eb087aef707fa0c5686d33d6ff61f4a555",
+                "reference": "6e04d0eb087aef707fa0c5686d33d6ff61f4a555",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.10.57"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-05T09:01:07+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -9,15 +9,12 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withPhpSets(
-        php82: true
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        codingStyle: true,
+        privatization: true,
+        naming: true,
+        instanceOf: true,
+        earlyReturn: true,
     );
-//    ->withPreparedSets(
-//        deadCode: true,
-//        codeQuality: true,
-//        codingStyle: true,
-//        privatization: true,
-//        naming: true,
-//        instanceof: true,
-//        earlyReturn: true,
-//    );

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ return RectorConfig::configure()
         deadCode: true,
         codeQuality: true,
         codingStyle: true,
+        typeDeclarations: true,
         privatization: true,
         naming: true,
         instanceOf: true,

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(
+        php82: true
+    );
+//    ->withPreparedSets(
+//        deadCode: true,
+//        codeQuality: true,
+//        codingStyle: true,
+//        privatization: true,
+//        naming: true,
+//        instanceof: true,
+//        earlyReturn: true,
+//    );

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,15 +24,12 @@ class Client implements EmarsysClientInterface
 
     public const LIVE_BASE_URL = 'https://api.emarsys.net/api/v2/';
 
-    /**
-     * @var string
-     */
-    private $baseUrl;
+    private string $baseUrl;
 
     /**
-     * @var array
+     * @var string[]
      */
-    private $systemFields = [
+    private array $systemFields = [
         'key_id',
         'id',
         'contacts',

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,41 +26,6 @@ class Client implements EmarsysClientInterface
     private $baseUrl;
 
     /**
-     * @var string
-     */
-    private $username;
-
-    /**
-     * @var string
-     */
-    private $secret;
-
-    /**
-     * @var HttpClientInterface
-     */
-    private $client;
-
-    /**
-     * @var RequestFactoryInterface
-     */
-    private $requestFactory;
-
-    /**
-     * @var StreamFactoryInterface
-     */
-    private $streamFactory;
-
-    /**
-     * @var array
-     */
-    private $fieldsMapping;
-
-    /**
-     * @var array
-     */
-    private $choicesMapping;
-
-    /**
      * @var array
      */
     private $systemFields = [
@@ -81,23 +46,15 @@ class Client implements EmarsysClientInterface
      * @param array                   $choicesMapping Overrides the default choices mapping if needed
      */
     public function __construct(
-        HttpClientInterface $client,
-        RequestFactoryInterface $requestFactory,
-        StreamFactoryInterface $streamFactory,
-        string $username,
-        string $secret,
+        private readonly HttpClientInterface $client,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly string $username,
+        private readonly string $secret,
         ?string $baseUrl = null,
-        array $fieldsMapping = [],
-        array $choicesMapping = []
+        private array $fieldsMapping = [],
+        private array $choicesMapping = []
     ) {
-        $this->client = $client;
-        $this->requestFactory = $requestFactory;
-        $this->streamFactory = $streamFactory;
-        $this->username = $username;
-        $this->secret = $secret;
-        $this->fieldsMapping = $fieldsMapping;
-        $this->choicesMapping = $choicesMapping;
-
         $this->baseUrl = $baseUrl ?? $this::LIVE_BASE_URL;
 
         if (empty($this->fieldsMapping)) {
@@ -654,9 +611,6 @@ class Client implements EmarsysClientInterface
     /**
      * Send an HTTP request
      *
-     * @param string $uri
-     * @param array  $body
-     * @param string $method
      *
      * @return Response
      * @throws ClientException
@@ -732,7 +686,6 @@ class Client implements EmarsysClientInterface
     /**
      * Convert field string ids to field ids
      *
-     * @param array $data
      *
      * @return array
      * @throws ClientException
@@ -753,8 +706,6 @@ class Client implements EmarsysClientInterface
     }
 
     /**
-     * @param string $filename
-     *
      * @return mixed
      */
     private function readJsonFile(string $filename)
@@ -857,8 +808,6 @@ class Client implements EmarsysClientInterface
     }
 
     /**
-     * @param array $data
-     *
      * @return array
      */
     private function mapFieldsForMultipleContacts(array $data): array
@@ -871,10 +820,7 @@ class Client implements EmarsysClientInterface
             $data,
             [
                 'contacts' => array_map(
-                    [
-                        $this,
-                        'mapFieldsToIds',
-                    ],
+                    $this->mapFieldsToIds(...),
                     $data['contacts']
                 ),
             ]

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -50,8 +50,6 @@ interface ClientInterface
      *      'myCustomField' => 7147,
      *      'myCustomField2' => 7148,
      *  ];
-     *
-     * @param array $mapping
      */
     public function addFieldsMapping(array $mapping = []): void;
 
@@ -66,15 +64,12 @@ interface ClientInterface
      *          'myCustomChoice2' => 2,
      *      ]
      *  ];
-     *
-     * @param array $mapping
      */
     public function addChoicesMapping(array $mapping = []): void;
 
     /**
      * Returns a field id from a field string_id (specified in the fields mapping)
      *
-     * @param string $fieldStringId
      *
      * @return int
      * @throws ClientException
@@ -106,7 +101,6 @@ interface ClientInterface
      * mapping is found
      *
      * @param string|int $fieldId
-     * @param int $choiceId
      *
      * @return string|int
      * @throws ClientException
@@ -131,7 +125,6 @@ interface ClientInterface
      *      'source_id' => '123',
      *  );
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -142,7 +135,6 @@ interface ClientInterface
     /**
      * Updates one or more contacts/recipients, identified by an external ID.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -154,7 +146,6 @@ interface ClientInterface
      * Updates one or more contacts/recipients, identified by an external ID. If the contact does not exist in the
      * database, it is created.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -165,7 +156,6 @@ interface ClientInterface
     /**
      * Deletes a single contact/recipient, identified by an external ID.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -176,8 +166,6 @@ interface ClientInterface
     /**
      * Returns the internal ID of a contact specified by its external ID.
      *
-     * @param string $fieldId
-     * @param string $fieldValue
      *
      * @return int
      * @throws ClientException
@@ -188,7 +176,6 @@ interface ClientInterface
     /**
      * Exports the selected fields of all contacts with properties changed in the time range specified.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -199,7 +186,6 @@ interface ClientInterface
     /**
      * Returns the list of emails sent to the specified contacts.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -219,7 +205,6 @@ interface ClientInterface
      *                                                                          // the column used to select contacts.
      *  );
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -230,7 +215,6 @@ interface ClientInterface
     /**
      * Exports the selected fields of all contacts which registered in the specified time range.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -241,7 +225,6 @@ interface ClientInterface
     /**
      * Returns a list of contact lists which can be used as recipient source for the email.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -252,7 +235,6 @@ interface ClientInterface
     /**
      * Creates a contact list which can be used as recipient source for the email.
      *
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -263,7 +245,6 @@ interface ClientInterface
     /**
      * Deletes a contact list which can be used as recipient source for the email.
      *
-     * @param string $listId
      *
      * @return Response
      * @throws ClientException
@@ -274,8 +255,6 @@ interface ClientInterface
     /**
      * Creates a contact list which can be used as recipient source for the email.
      *
-     * @param string $listId
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -286,8 +265,6 @@ interface ClientInterface
     /**
      * This deletes contacts from the contact list which can be used as recipient source for the email.
      *
-     * @param string $listId
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -298,8 +275,6 @@ interface ClientInterface
     /**
      * Get a list of contact IDs that are in a contact list
      *
-     * @param string $listId
-     * @param array $data
      *
      * @return Response
      * @throws ClientException
@@ -310,8 +285,6 @@ interface ClientInterface
     /**
      * Checks whether a specific contact is included in the defined contact list.
      *
-     * @param int $contactId
-     * @param int $listId
      *
      * @return Response
      * @throws ClientException
@@ -323,13 +296,9 @@ interface ClientInterface
     /**
      * Returns a list of emails.
      *
-     * @param int|null $status
-     * @param int|null $contactList
-     * @param array $campaignTypes
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
+     *
      * @link https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns
      */
     public function getEmails(?int $status = null, ?int $contactList = null, array $campaignTypes): Response;
@@ -352,9 +321,6 @@ interface ClientInterface
      *      'browse' => 0,
      *  );
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -363,10 +329,6 @@ interface ClientInterface
     /**
      * Returns the attributes of an email and the personalized text and HTML source.
      *
-     * @param string $emailId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -375,10 +337,6 @@ interface ClientInterface
     /**
      * Launches an email. This is an asynchronous call, which returns 'OK' if the email is able to launch.
      *
-     * @param string $emailId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -387,10 +345,6 @@ interface ClientInterface
     /**
      * Returns the HTML or text version of the email either as content type 'application/json' or 'text/html'.
      *
-     * @param string $emailId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -399,24 +353,14 @@ interface ClientInterface
     /**
      * Returns the summary of the responses of a launched, paused, activated or deactivated email.
      *
-     * @param string      $emailId
-     * @param string|null $startDate
-     * @param string|null $endDate
-     * @param string|null $launchId
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
-    public function getEmailResponseSummary(string $emailId, ?string $startDate = null, ?string $endDate = null, string $launchId = null): Response;
+    public function getEmailResponseSummary(string $emailId, ?string $startDate = null, ?string $endDate = null, ?string $launchId = null): Response;
 
     /**
      * Instructs the system to send a test email.
      *
-     * @param string $emailId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -425,10 +369,6 @@ interface ClientInterface
     /**
      * Returns the URL to the online version of an email, provided it has been sent to the specified contact.
      *
-     * @param string $emailId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -437,9 +377,6 @@ interface ClientInterface
     /**
      * Returns the delivery status of an email.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -448,9 +385,6 @@ interface ClientInterface
     /**
      * Lists all the launches of an email with ID, launch date and 'done' status.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -459,9 +393,6 @@ interface ClientInterface
     /**
      * Exports the selected fields of all contacts which responded to emails in the specified time range.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -470,9 +401,6 @@ interface ClientInterface
     /**
      * Flags contacts as unsubscribed for an email campaign launch so they will be included in the campaign statistics.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -481,9 +409,6 @@ interface ClientInterface
     /**
      * Returns a list of email categories which can be used in email creation.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -492,7 +417,6 @@ interface ClientInterface
     /**
      * Returns a list of external events which can be used in program s .
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -501,10 +425,6 @@ interface ClientInterface
     /**
      * Triggers the given event for the specified contact.
      *
-     * @param string $eventId
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -513,9 +433,6 @@ interface ClientInterface
     /**
      * Fetches the status data of an export.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -524,7 +441,6 @@ interface ClientInterface
     /**
      * Returns a list of fields (including custom fields and vouchers) which can be used to personalize content.
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -535,7 +451,6 @@ interface ClientInterface
      *
      * @param string $fieldId Field ID or custom field name (available in fields mapping)
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -544,9 +459,6 @@ interface ClientInterface
     /**
      * Returns a customer's files.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -555,9 +467,6 @@ interface ClientInterface
     /**
      * Uploads a file to a media database.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -566,9 +475,6 @@ interface ClientInterface
     /**
      * Returns a list of segments which can be used as recipient source for the email.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -577,9 +483,6 @@ interface ClientInterface
     /**
      * Returns a customer's folders.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -588,9 +491,6 @@ interface ClientInterface
     /**
      * Returns a list of the customer's forms.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -599,7 +499,6 @@ interface ClientInterface
     /**
      * Returns a list of languages which you can use in email creation.
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -608,7 +507,6 @@ interface ClientInterface
     /**
      * Returns a list of sources which can be used for creating contacts.
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -617,9 +515,6 @@ interface ClientInterface
     /**
      * Deletes an existing source.
      *
-     * @param string $sourceId
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -628,9 +523,6 @@ interface ClientInterface
     /**
      * Creates a new source for the customer with the specified name.
      *
-     * @param array $data
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -639,10 +531,8 @@ interface ClientInterface
     /**
      * Creates custom field in your Emarsys account
      *
-     * @param string $name
      * @param string $applicationType shorttext|longtext|largetext|date|url|numeric
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -651,10 +541,6 @@ interface ClientInterface
     /**
      * Adds a list of emails and domains to the blacklist
      *
-     * @param array $emails
-     * @param array $domains
-     *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -663,7 +549,6 @@ interface ClientInterface
     /**
      * Returns the current settings of the specified customer account, such as timezone or name.
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -8,32 +8,49 @@ use Snowcap\Emarsys\Exception\ServerException;
 interface ClientInterface
 {
     public const LAUNCH_STATUS_NOT_LAUNCHED = 0;
+
     public const LAUNCH_STATUS_IN_PROGRESS = 1;
+
     public const LAUNCH_STATUS_LAUNCHED_OR_SCHEDULED = 2;
+
     public const LAUNCH_STATUS_ERROR = 10;
 
     /**
      * @see https://dev.emarsys.com/v2/personalization/email-status-and-error-codes for codes
      */
     public const EMAIL_STATUS_CODE_ABORTED = -6;
+
     public const EMAIL_STATUS_CODE_PAUSED_ABORTED = -4;
+
     public const EMAIL_STATUS_CODE_LAUNCHED_PAUSED = -3;
+
     public const EMAIL_STATUS_CODE_TESTED_PAUSED = -2;
+
     public const EMAIL_STATUS_CODE_IN_DESIGN = 1;
+
     public const EMAIL_STATUS_CODE_TESTED = 2;
+
     public const EMAIL_STATUS_CODE_LAUNCHED = 3;
+
     public const EMAIL_STATUS_CODE_READY_TO_LAUNCH = 4;
+
     public const EMAIL_STATUS_CODE_NOT_LAUNCHED = 5;
 
     /**
      * @see https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns
      */
     public const CAMPAIGN_TYPE_ADHOC = 'adhoc';
+
     public const CAMPAIGN_TYPE_RECURRING = 'recurring';
+
     public const CAMPAIGN_TYPE_NEWSLETTER = 'newsletter';
+
     public const CAMPAIGN_TYPE_ON_EVENT = 'onevent';
+
     public const CAMPAIGN_TYPE_TEST_EMAIL = 'testemail';
+
     public const CAMPAIGN_TYPE_MULTILANGUAGE = 'multilanguage';
+
     public const CAMPAIGN_TYPE_BROADCAST = 'broadcast';
 
     /**
@@ -71,7 +88,6 @@ interface ClientInterface
      * Returns a field id from a field string_id (specified in the fields mapping)
      *
      *
-     * @return int
      * @throws ClientException
      */
     public function getFieldId(string $fieldStringId): int;
@@ -91,7 +107,6 @@ interface ClientInterface
      * @param string|int $fieldStringId
      * @param string|int $choice
      *
-     * @return int
      * @throws ClientException
      */
     public function getChoiceId($fieldStringId, $choice): int;
@@ -110,7 +125,6 @@ interface ClientInterface
     /**
      * Returns a list of condition rules.
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -126,7 +140,6 @@ interface ClientInterface
      *  );
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -136,7 +149,6 @@ interface ClientInterface
      * Updates one or more contacts/recipients, identified by an external ID.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -147,7 +159,6 @@ interface ClientInterface
      * database, it is created.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -157,7 +168,6 @@ interface ClientInterface
      * Deletes a single contact/recipient, identified by an external ID.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -167,7 +177,6 @@ interface ClientInterface
      * Returns the internal ID of a contact specified by its external ID.
      *
      *
-     * @return int
      * @throws ClientException
      * @throws ServerException
      */
@@ -177,7 +186,6 @@ interface ClientInterface
      * Exports the selected fields of all contacts with properties changed in the time range specified.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -187,7 +195,6 @@ interface ClientInterface
      * Returns the list of emails sent to the specified contacts.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -206,7 +213,6 @@ interface ClientInterface
      *  );
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -216,7 +222,6 @@ interface ClientInterface
      * Exports the selected fields of all contacts which registered in the specified time range.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -226,7 +231,6 @@ interface ClientInterface
      * Returns a list of contact lists which can be used as recipient source for the email.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -236,7 +240,6 @@ interface ClientInterface
      * Creates a contact list which can be used as recipient source for the email.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -246,7 +249,6 @@ interface ClientInterface
      * Deletes a contact list which can be used as recipient source for the email.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -256,7 +258,6 @@ interface ClientInterface
      * Creates a contact list which can be used as recipient source for the email.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -266,7 +267,6 @@ interface ClientInterface
      * This deletes contacts from the contact list which can be used as recipient source for the email.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -276,7 +276,6 @@ interface ClientInterface
      * Get a list of contact IDs that are in a contact list
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      */
@@ -286,7 +285,6 @@ interface ClientInterface
      * Checks whether a specific contact is included in the defined contact list.
      *
      *
-     * @return Response
      * @throws ClientException
      * @throws ServerException
      * @link http://documentation.emarsys.com/resource/developers/endpoints/contacts/check-a-contact-in-a-contact-list/
@@ -301,7 +299,7 @@ interface ClientInterface
      *
      * @link https://dev.emarsys.com/docs/emarsys-api/b3A6MjQ4OTk4Njg-list-email-campaigns
      */
-    public function getEmails(?int $status = null, ?int $contactList = null, array $campaignTypes): Response;
+    public function getEmails(?int $status = null, ?int $contactList = null, array $campaignTypes = []): Response;
 
     /**
      * Creates an email in eMarketing Suite and assigns it the respective parameters.

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -15,27 +15,16 @@ class ClientException extends Exception
     public const SYSTEM_TYPE_NOT_CREATABLE_EXCEPTION = 'Can\'t create this type of field, system type.';
     public const TYPE_NOT_CREATABLE_VIA_API_EXCEPTION = 'This type of field cannot be created via API. %s';
 
-    /**
-     * @return ClientException
-     */
     public static function invalidResponseStructure(): ClientException
     {
         return new self(self::UNEXPECTED_RESPONSE_STRUCTURE_MESSAGE);
     }
 
-    /**
-     * @return ClientException
-     */
     public static function jsonMaximumDepthDecodingException(): ClientException
     {
         return new self(self::JSON_MAXIMUM_DEPTH_DECODE_EXCEPTION);
     }
 
-    /**
-     * @param string $fieldName
-     *
-     * @return ClientException
-     */
     public static function unrecognizedFieldName(string $fieldName): ClientException
     {
         return new self(
@@ -46,11 +35,6 @@ class ClientException extends Exception
         );
     }
 
-    /**
-     * @param string $fieldStringId
-     *
-     * @return ClientException
-     */
     public static function unrecognizedFieldStringId(string $fieldStringId): ClientException
     {
         return new self(
@@ -61,12 +45,6 @@ class ClientException extends Exception
         );
     }
 
-    /**
-     * @param string $fieldStringId
-     * @param string $choice
-     *
-     * @return ClientException
-     */
     public static function unrecognizedFieldStringIdForChoice(string $fieldStringId, string $choice): ClientException
     {
         return new self(
@@ -78,12 +56,6 @@ class ClientException extends Exception
         );
     }
 
-    /**
-     * @param string $choice
-     * @param string $fieldStringId
-     *
-     * @return ClientException
-     */
     public static function unrecognizedChoiceForFieldStringId(string $choice, string $fieldStringId): ClientException
     {
         return new self(
@@ -95,19 +67,11 @@ class ClientException extends Exception
         );
     }
 
-    /**
-     * @return ClientException
-     */
     public static function cannotCreateSystemTypeException(): ClientException
     {
         return new self(self::SYSTEM_TYPE_NOT_CREATABLE_EXCEPTION);
     }
 
-    /**
-     * @param string $type
-     *
-     * @return ClientException
-     */
     public static function typeNotCreatableViaApiException(string $type): ClientException
     {
         return new self(

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -7,12 +7,19 @@ use Exception;
 class ClientException extends Exception
 {
     public const UNEXPECTED_RESPONSE_STRUCTURE_MESSAGE = 'Unexpect response structure, no replyCode or replyText';
+
     public const JSON_MAXIMUM_DEPTH_DECODE_EXCEPTION = 'JSON response could not be decoded, maximum depth reached.';
+
     public const UNRECOGNIZED_FIELD_NAME = 'Unrecognized field name "%s"';
+
     public const UNRECOGNIZED_FIELD_STRING_ID = 'Unrecognized field string_id "%s"';
+
     public const UNRECOGNIZED_FIELD_ID_FOR_CHOICE = 'Unrecognized field "%s" for choice "%s"';
+
     public const UNRECOGNIZED_CHOICE_FOR_FIELD_ID = 'Unrecognized choice "%s" for field "%s"';
-    public const SYSTEM_TYPE_NOT_CREATABLE_EXCEPTION = 'Can\'t create this type of field, system type.';
+
+    public const SYSTEM_TYPE_NOT_CREATABLE_EXCEPTION = "Can't create this type of field, system type.";
+
     public const TYPE_NOT_CREATABLE_VIA_API_EXCEPTION = 'This type of field cannot be created via API. %s';
 
     public static function invalidResponseStructure(): ClientException

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -7,6 +7,7 @@ use Exception;
 class ServerException extends Exception
 {
     public const JSON_DECODING_EXCEPTION = 'JSON response could not be decoded:\n%s';
+
     public const JSON_RESPONSE_NOT_ARRAY_EXCEPTION = 'JSON response is not an array:\n%s';
 
     public static function jsonDecodingException(string $msg): ServerException

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -9,11 +9,6 @@ class ServerException extends Exception
     public const JSON_DECODING_EXCEPTION = 'JSON response could not be decoded:\n%s';
     public const JSON_RESPONSE_NOT_ARRAY_EXCEPTION = 'JSON response is not an array:\n%s';
 
-    /**
-     * @param string $msg
-     *
-     * @return ServerException
-     */
     public static function jsonDecodingException(string $msg): ServerException
     {
         return new self(
@@ -24,11 +19,6 @@ class ServerException extends Exception
         );
     }
 
-    /**
-     * @param string $response
-     *
-     * @return ServerException
-     */
     public static function jsonResponseNotArrayException(string $response): ServerException
     {
         return new self(

--- a/src/Response.php
+++ b/src/Response.php
@@ -21,12 +21,19 @@ class Response
      * https://dev.emarsys.com/v2/response-codes/error-codes
      */
     public const REPLY_CODE_OK = 0;
+
     public const REPLY_CODE_INTERNAL_ERROR = 1;
+
     public const REPLY_CODE_INVALID_KEY_FIELD = 2004;
+
     public const REPLY_CODE_MISSING_KEY_FIELD = 2005;
+
     public const REPLY_CODE_CONTACT_NOT_FOUND = 2008;
+
     public const REPLY_CODE_NON_UNIQUE_RESULT = 2010;
+
     public const REPLY_CODE_INVALID_STATUS = 6003;
+
     public const REPLY_CODE_INVALID_DATA = 10001;
 
     /**
@@ -58,25 +65,16 @@ class Response
         $this->data = $result['data'] ?? [];
     }
 
-    /**
-     * @return array
-     */
     public function getData(): array
     {
         return $this->data;
     }
 
-    /**
-     * @return int
-     */
     public function getReplyCode(): int
     {
         return $this->replyCode;
     }
 
-    /**
-     * @return string
-     */
     public function getReplyText(): string
     {
         return $this->replyText;

--- a/src/Response.php
+++ b/src/Response.php
@@ -15,16 +15,19 @@ use Snowcap\Emarsys\Exception\ClientException;
  */
 class Response
 {
-    // Successful requests return with replyCode 0.
-    // https://dev.emarsys.com/v2/response-codes/error-codes
-    const REPLY_CODE_OK = 0;
-    const REPLY_CODE_INTERNAL_ERROR = 1;
-    const REPLY_CODE_INVALID_KEY_FIELD = 2004;
-    const REPLY_CODE_MISSING_KEY_FIELD = 2005;
-    const REPLY_CODE_CONTACT_NOT_FOUND = 2008;
-    const REPLY_CODE_NON_UNIQUE_RESULT = 2010;
-    const REPLY_CODE_INVALID_STATUS = 6003;
-    const REPLY_CODE_INVALID_DATA = 10001;
+    /**
+     * Successful requests return with replyCode 0.
+     *
+     * https://dev.emarsys.com/v2/response-codes/error-codes
+     */
+    public const REPLY_CODE_OK = 0;
+    public const REPLY_CODE_INTERNAL_ERROR = 1;
+    public const REPLY_CODE_INVALID_KEY_FIELD = 2004;
+    public const REPLY_CODE_MISSING_KEY_FIELD = 2005;
+    public const REPLY_CODE_CONTACT_NOT_FOUND = 2008;
+    public const REPLY_CODE_NON_UNIQUE_RESULT = 2010;
+    public const REPLY_CODE_INVALID_STATUS = 6003;
+    public const REPLY_CODE_INVALID_DATA = 10001;
 
     /**
      * @var int
@@ -42,8 +45,6 @@ class Response
     protected $data = [];
 
     /**
-     * @param array $result
-     *
      * @throws ClientException
      */
     public function __construct(array $result = [])

--- a/tests/Integration/Suites/EmarsysTest.php
+++ b/tests/Integration/Suites/EmarsysTest.php
@@ -49,7 +49,6 @@ class EmarsysTest extends TestCase
     }
 
     /**
-     * @covers Client::getLanguages
      * @throws ServerException
      * @throws ClientException
      * @throws Exception
@@ -68,7 +67,6 @@ class EmarsysTest extends TestCase
     }
 
     /**
-     * @covers Client::getFields
      * @throws ServerException
      * @throws ClientException
      * @throws Exception

--- a/tests/Integration/Suites/EmarsysTest.php
+++ b/tests/Integration/Suites/EmarsysTest.php
@@ -17,7 +17,7 @@ class EmarsysTest extends TestCase
     /**
      * @var ClientInterface
      */
-    private $client;
+    private Client $client;
 
     /**
      * @throws ClientException

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -24,7 +24,7 @@
                 <directory>.</directory>
         </testsuite>
         <php>
-                <const name="EMARSYS_API_USERNAME" value="your_username"/>
-                <const name="EMARSYS_API_SECRET" value="your_secret"/>
+                <env name="EMARSYS_API_USERNAME" value="your_username"/>
+                <env name="EMARSYS_API_SECRET" value="your_secret"/>
         </php>
 </phpunit>

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
         backupGlobals="false"
         backupStaticAttributes="false"
         bootstrap="../../vendor/autoload.php"

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Snowcap\Emarsys\Client;
 use Snowcap\Emarsys\ClientInterface;
 use Snowcap\Emarsys\Exception\ClientException;
@@ -331,14 +332,7 @@ class ClientTest extends TestCase
         self::assertEquals(90, $response->getData()['sent']);
     }
 
-    /**
-     * Get a json test data and decode it
-     *
-     * @param string $fileName
-     *
-     * @return mixed
-     */
-    private function createExpectedResponse(string $fileName)
+    private function createExpectedResponse(string $fileName): StreamInterface
     {
         return Utils::streamFor(file_get_contents(__DIR__ . '/TestData/' . $fileName . '.json'));
     }

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -26,12 +26,12 @@ class ClientTest extends TestCase
     /**
      * @var MockObject|ClientInterface
      */
-    private $client;
+    private Client $client;
 
     /**
      * @var MockObject|MockClient
      */
-    private $stubHttpClient;
+    private MockClient $stubHttpClient;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Psr7\Utils;
 use Http\Factory\Guzzle\RequestFactory;
 use Http\Factory\Guzzle\StreamFactory;
 use Http\Mock\Client as MockClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +19,8 @@ use Snowcap\Emarsys\Exception\ClientException;
 use Snowcap\Emarsys\Exception\ServerException;
 use Snowcap\Emarsys\Response;
 
-/**
- * @covers \Snowcap\Emarsys\Client
- * @uses   \Snowcap\Emarsys\Response
- */
+#[CoversClass(Client::class)]
+#[UsesClass(Response::class)]
 class ClientTest extends TestCase
 {
     /**

--- a/tests/Unit/Suites/ClientTest.php
+++ b/tests/Unit/Suites/ClientTest.php
@@ -303,7 +303,7 @@ class ClientTest extends TestCase
         $this->expectException(ClientException::class);
         $this->expectExceptionMessage('JSON response could not be decoded, maximum depth reached.');
         $nestedStructure = [];
-        for ($i = 0; $i < 511; $i++) {
+        for ($i = 0; $i < 511; ++$i) {
             $nestedStructure = [$nestedStructure];
         }
 

--- a/tests/Unit/Suites/ResponseTest.php
+++ b/tests/Unit/Suites/ResponseTest.php
@@ -66,12 +66,7 @@ class ResponseTest extends TestCase
         self::assertEmpty($result->getData());
     }
 
-    /**
-     * @param string $fileName
-     *
-     * @return mixed
-     */
-    private function createExpectedResponse(string $fileName)
+    private function createExpectedResponse(string $fileName): array
     {
         $fileContent = file_get_contents(__DIR__ . '/TestData/' . $fileName . '.json');
 

--- a/tests/Unit/Suites/ResponseTest.php
+++ b/tests/Unit/Suites/ResponseTest.php
@@ -28,9 +28,9 @@ class ResponseTest extends TestCase
     public function testItGetsResponseData(): void
     {
         $expectedResponse = $this->createExpectedResponse('createContact');
-        $result = new Response($expectedResponse);
+        $response = new Response($expectedResponse);
 
-        self::assertNotEmpty($result);
+        self::assertNotEmpty($response);
     }
 
     /**
@@ -39,9 +39,9 @@ class ResponseTest extends TestCase
     public function testItSetsAndGetsReplyCode(): void
     {
         $expectedResponse = $this->createExpectedResponse('createContact');
-        $result = new Response($expectedResponse);
+        $response = new Response($expectedResponse);
 
-        self::assertSame(Response::REPLY_CODE_OK, $result->getReplyCode());
+        self::assertSame(Response::REPLY_CODE_OK, $response->getReplyCode());
     }
 
     /**
@@ -50,9 +50,9 @@ class ResponseTest extends TestCase
     public function testItSetsAndGetsReplyText(): void
     {
         $expectedResponse = $this->createExpectedResponse('createContact');
-        $result = new Response($expectedResponse);
+        $response = new Response($expectedResponse);
 
-        self::assertEquals('OK', $result->getReplyText());
+        self::assertEquals('OK', $response->getReplyText());
     }
 
     /**
@@ -61,9 +61,9 @@ class ResponseTest extends TestCase
     public function testItResponseWithoutData(): void
     {
         $expectedResponse = $this->createExpectedResponse('insertRecord');
-        $result = new Response($expectedResponse);
+        $response = new Response($expectedResponse);
 
-        self::assertEmpty($result->getData());
+        self::assertEmpty($response->getData());
     }
 
     private function createExpectedResponse(string $fileName): array

--- a/tests/Unit/Suites/ResponseTest.php
+++ b/tests/Unit/Suites/ResponseTest.php
@@ -2,13 +2,12 @@
 
 namespace Snowcap\Emarsys\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Snowcap\Emarsys\Exception\ClientException;
 use Snowcap\Emarsys\Response;
 
-/**
- * @covers \Snowcap\Emarsys\Response
- */
+#[CoversClass(Response::class)]
 class ResponseTest extends TestCase
 {
     /**

--- a/tests/Unit/phpunit.xml.dist
+++ b/tests/Unit/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
         backupGlobals="false"
         backupStaticAttributes="false"
         bootstrap="../../vendor/autoload.php"


### PR DESCRIPTION
## Description
Continuation of: https://github.com/mention-me/Emarsys/pull/91

This does:
1. Bumps to PHPUnit 10 (preferable for some rector rules - and okay to move to after the changes in Part 1)
2. Applies Rector rules for PHP up to 8.2 (what is now listed in the composer file)
3. Applies Rector rules for PHPUnit up to 10
4. Applies some standard Rector rules for code hygiene (mostly removing docblocks which aren't needed and adding types which are supported)
5. Adds Rector to CI pipeline (to run code hygiene rules)

## Testing Notes
Will hook this up to the platform locally before merging and test both Part 1 and 2 together. Once thats done, I'll get merging!