### PR TITLE
Update action branch trigger

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,7 +3,7 @@ name: PHP Composer
 on:
   push:
     branches:
-      - main
+      - master
 
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
## Description
We weren't triggering GitHub workflows on merge, because I got the branch name wrong.

This fixes it.

## Testing Notes
N/A

## Deployment Notes
N/A